### PR TITLE
Add registration workflow to facilitate releases

### DIFF
--- a/.github/workflows/RegisterPackage.yml
+++ b/.github/workflows/RegisterPackage.yml
@@ -1,0 +1,14 @@
+name: Register Package
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version to register or component to bump
+        required: true
+jobs:
+  register:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: julia-actions/RegisterAction@latest
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I've just added a workflow file to register Julia packages via GitHub Actions.

For further details see [here](https://github.com/julia-actions/RegisterAction). 