### PR TITLE
Add `@glimpse` and `@relocate`

### DIFF
--- a/src/Tidier.jl
+++ b/src/Tidier.jl
@@ -16,7 +16,7 @@ using Reexport
 export Tidier_set, across, desc, n, row_number, starts_with, ends_with, matches, if_else, case_when, ntile, 
       @select, @transmute, @rename, @mutate, @summarize, @summarise, @filter, @group_by, @ungroup, @slice, 
       @arrange, @distinct, @pull, @left_join, @right_join, @inner_join, @full_join, @pivot_wider, @pivot_longer, 
-      @bind_rows, @bind_cols, @clean_names, @count, @tally
+      @bind_rows, @bind_cols, @clean_names, @count, @tally, @glimpse
 
 # Package global variables
 const code = Ref{Bool}(false) # output DataFrames.jl code?
@@ -611,4 +611,24 @@ macro pull(df, column)
   return vec_expr
 end
 
+macro glimpse(df)
+  df_expr = quote
+    local des_df = describe($(esc(df)), :eltype, :mean, :min, :median, :max, :nmissing; cols=:)
+    show(des_df, allrows=true)
+  end
+  if code[]
+    @info MacroTools.prettify(df_expr)
+  end
+  return df_expr
 end
+
+macro relocate(df, exprs...)
+end
+
+end
+
+using .Tidier
+
+df1 = DataFrame(a=1:3, b=1:3, c=4:6, d=4:6, e=7:9, f=["7", "8","9"]);
+
+@glimpse(df1)

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -405,11 +405,31 @@ function parse_bind_args(tidy_expr::Union{Expr,Symbol})
   found_id = false
   if @capture(tidy_expr, lhs_ = rhs_)
     if lhs != :id
-      throw("$(String(lhs)) is not implemented")
+      throw("$(String(lhs)) argument is not supported")
     else
       found_id = true
       return rhs, found_id
     end
   end
   return esc(tidy_expr), found_id
+end
+
+# Not export
+function parse_relocate_args(tidy_expr::Union{Expr,Symbol}...)
+  col_names = Union{Expr,Symbol}[]
+  after = nothing
+  before = nothing
+
+  for expr in tidy_exprs
+    if @capture(expr, after = rhs_)
+      after = rhs
+    elseif @capture(expr, before = rhs_)
+      before = rhs
+    elseif @capture(count_expr, lhs_ = rhs_)
+      throw("$(String(lhs)) argument is not supported")
+    else
+      push!(col_names, expr)
+    end
+  end
+  return col_names, before, after
 end

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -415,17 +415,19 @@ function parse_bind_args(tidy_expr::Union{Expr,Symbol})
 end
 
 # Not export
-function parse_relocate_args(tidy_expr::Union{Expr,Symbol}...)
+function parse_relocate_args(tidy_exprs::Union{Expr,Symbol}...)
   col_names = Union{Expr,Symbol}[]
   after = nothing
   before = nothing
 
   for expr in tidy_exprs
-    if @capture(expr, after = rhs_)
+    if @capture(expr, after = rhs_) && @capture(expr, before = rhs_)
+      throw("before and after cannot be specified at the same time")s
+    elseif @capture(expr, after = rhs_) 
       after = rhs
     elseif @capture(expr, before = rhs_)
       before = rhs
-    elseif @capture(count_expr, lhs_ = rhs_)
+    elseif @capture(expr, lhs_ = rhs_)
       throw("$(String(lhs)) argument is not supported")
     else
       push!(col_names, expr)


### PR DESCRIPTION
These two macros are sort of nice-to-have features. Therefore I wish to add them.

Seems that `DataFrames.jl` does not have similar feature as tidyverse's `glimpse()`. The workaround I propose is using `describe()` to print summary information for each column and force the it to print all rows of the summary table in `stdout`. For example:

```
julia> df1 = DataFrame(a=1:3, b=1:3, c=4:6, d=4:6, e=7:9, f1=["7", "8","9"], f2=7:9);

julia> @glimpse(df1)
7×7 DataFrame
 Row │ variable  eltype    mean    min  median  max  nmissing 
     │ Symbol    DataType  Union…  Any  Union…  Any  Int64    
─────┼────────────────────────────────────────────────────────
   1 │ a         Int64     2.0     1    2.0     3           0
   2 │ b         Int64     2.0     1    2.0     3           0
   3 │ c         Int64     5.0     4    5.0     6           0
   4 │ d         Int64     5.0     4    5.0     6           0
   5 │ e         Int64     8.0     7    8.0     9           0
   6 │ f1        String            7            9           0
   7 │ f2        Int64     8.0     7    8.0     9           0
```

Right now `@relocate` support following use cases:

```
@relocate(df1, d)
@relocate(df1, d, f)
@relocate(df1, f1, before =a)
@relocate(df1, f, before =(b,c))
@relocate(df1, contains("f"), after = a:c)
@relocate(df1, f1, before =contains("b"))
```